### PR TITLE
feat: add member logic with old pattern

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
     // db
     runtimeOnly 'com.mysql:mysql-connector-j'
-    // implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/hanghae/hanghaeplus3/member/controller/MemberController.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/controller/MemberController.java
@@ -1,21 +1,37 @@
 package com.hanghae.hanghaeplus3.member.controller;
 
+import com.hanghae.hanghaeplus3.member.controller.request.ChargeBalanceRequest;
+import com.hanghae.hanghaeplus3.member.controller.response.ChargeBalanceResponse;
+import com.hanghae.hanghaeplus3.member.service.AccountService;
+import com.hanghae.hanghaeplus3.member.service.domain.Account;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Slf4j
 @RestController
-@RequestMapping("/member")
+@RequestMapping("/members")
+@RequiredArgsConstructor
 public class MemberController {
+    private final AccountService accountService;
 
     @GetMapping("/{id}/balance")
     public ResponseEntity<?> findBalanceOf(@PathVariable Long id) {
-        return ResponseEntity.ok("잔액 조회");
+        List<Account> result = accountService.findBalanceOf(id);
+        return ResponseEntity.ok(result);
     }
 
     @PutMapping("/{id}/balance/charge")
-    public ResponseEntity<?> chargeBalanceOf(@PathVariable Long id) {
-        return ResponseEntity.ok("잔액 충전");
+    public ResponseEntity<?> chargeBalanceOf(@PathVariable Long id,
+                                             @RequestBody ChargeBalanceRequest request) {
+        Account result = accountService.chargeBalance(id, request.accountId(), request.chargeBalance());
+        return ResponseEntity.ok(ChargeBalanceResponse.builder()
+                .memberId(result.getMemberId())
+                .accountId(result.getId())
+                .balance(result.getBalance())
+                .build());
     }
 }

--- a/src/main/java/com/hanghae/hanghaeplus3/member/controller/request/ChargeBalanceRequest.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/controller/request/ChargeBalanceRequest.java
@@ -1,0 +1,11 @@
+package com.hanghae.hanghaeplus3.member.controller.request;
+
+import lombok.Builder;
+
+public record ChargeBalanceRequest(
+        Long accountId,
+        Long chargeBalance
+) {
+    @Builder
+    public ChargeBalanceRequest {}
+}

--- a/src/main/java/com/hanghae/hanghaeplus3/member/controller/response/AccountResponse.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/controller/response/AccountResponse.java
@@ -1,0 +1,12 @@
+package com.hanghae.hanghaeplus3.member.controller.response;
+
+import lombok.Builder;
+
+public record AccountResponse(
+        Long id,
+        Long memberId,
+        Long balance
+) {
+    @Builder
+    public AccountResponse {}
+}

--- a/src/main/java/com/hanghae/hanghaeplus3/member/controller/response/ChargeBalanceResponse.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/controller/response/ChargeBalanceResponse.java
@@ -1,0 +1,12 @@
+package com.hanghae.hanghaeplus3.member.controller.response;
+
+import lombok.Builder;
+
+public record ChargeBalanceResponse(
+        Long memberId,
+        Long accountId,
+        Long balance
+) {
+    @Builder
+    public ChargeBalanceResponse {}
+}

--- a/src/main/java/com/hanghae/hanghaeplus3/member/controller/response/FindMembersResponse.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/controller/response/FindMembersResponse.java
@@ -1,0 +1,12 @@
+package com.hanghae.hanghaeplus3.member.controller.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+public record FindMembersResponse(
+        List<MemberResponse> members
+) {
+    @Builder
+    public FindMembersResponse {}
+}

--- a/src/main/java/com/hanghae/hanghaeplus3/member/controller/response/MemberResponse.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/controller/response/MemberResponse.java
@@ -1,0 +1,11 @@
+package com.hanghae.hanghaeplus3.member.controller.response;
+
+import lombok.Builder;
+
+public record MemberResponse(
+        Long id,
+        String name
+) {
+    @Builder
+    public MemberResponse {}
+}

--- a/src/main/java/com/hanghae/hanghaeplus3/member/controller/response/MemberWithAccountResponse.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/controller/response/MemberWithAccountResponse.java
@@ -1,0 +1,14 @@
+package com.hanghae.hanghaeplus3.member.controller.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+public record MemberWithAccountResponse(
+        Long id,
+        String name,
+        List<AccountResponse> accounts
+) {
+    @Builder
+    public MemberWithAccountResponse {}
+}

--- a/src/main/java/com/hanghae/hanghaeplus3/member/repository/AccountRepository.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/repository/AccountRepository.java
@@ -1,0 +1,12 @@
+package com.hanghae.hanghaeplus3.member.repository;
+
+import com.hanghae.hanghaeplus3.member.repository.entity.AccountEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AccountRepository extends JpaRepository<AccountEntity, Long> {
+    List<AccountEntity> findAccountByMemberId(Long memberId);
+}

--- a/src/main/java/com/hanghae/hanghaeplus3/member/repository/MemberRepository.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.hanghae.hanghaeplus3.member.repository;
+
+import com.hanghae.hanghaeplus3.member.repository.entity.MemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
+}

--- a/src/main/java/com/hanghae/hanghaeplus3/member/repository/entity/AccountEntity.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/repository/entity/AccountEntity.java
@@ -1,0 +1,42 @@
+package com.hanghae.hanghaeplus3.member.repository.entity;
+
+
+import com.hanghae.hanghaeplus3.member.service.domain.Account;
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "account")
+public class AccountEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Long memberId;
+
+    @Column
+    private Long balance;
+
+    @Column
+    private Long creator;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    public Account toDomain() {
+        return Account.builder()
+                .id(id)
+                .memberId(memberId)
+                .balance(balance)
+                .build();
+    }
+
+    public void chargeBalance(Long amount) {
+        this.balance += amount;
+    }
+}

--- a/src/main/java/com/hanghae/hanghaeplus3/member/repository/entity/MemberEntity.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/repository/entity/MemberEntity.java
@@ -1,0 +1,23 @@
+package com.hanghae.hanghaeplus3.member.repository.entity;
+
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member")
+public class MemberEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String name;
+
+    @Column
+    private Long creator;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/hanghae/hanghaeplus3/member/service/AccountService.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/service/AccountService.java
@@ -1,0 +1,38 @@
+package com.hanghae.hanghaeplus3.member.service;
+
+import com.hanghae.hanghaeplus3.member.repository.AccountRepository;
+import com.hanghae.hanghaeplus3.member.repository.entity.AccountEntity;
+import com.hanghae.hanghaeplus3.member.service.domain.Account;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(rollbackFor = Exception.class)
+public class AccountService {
+    private final AccountRepository accountRepository;
+
+    @Transactional(readOnly = true)
+    public List<Account> findBalanceOf(Long id) {
+        // TODO check exist member
+        return accountRepository.findAccountByMemberId(id).stream().map(AccountEntity::toDomain).toList();
+    }
+
+    public Account chargeBalance(Long memberId, Long accountId, Long amount) {
+        // TODO check member's account
+        AccountEntity account = accountRepository.findById(accountId)
+                .orElseThrow(IllegalArgumentException::new);
+        account.chargeBalance(amount);
+
+        return Account.builder()
+                .id(account.getId())
+                .memberId(account.getMemberId())
+                .balance(account.getBalance())
+                .build();
+    }
+}

--- a/src/main/java/com/hanghae/hanghaeplus3/member/service/MemberService.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/service/MemberService.java
@@ -1,9 +1,0 @@
-package com.hanghae.hanghaeplus3.member.service;
-
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-
-@Slf4j
-@Service
-public class MemberService {
-}

--- a/src/main/java/com/hanghae/hanghaeplus3/member/service/domain/Account.java
+++ b/src/main/java/com/hanghae/hanghaeplus3/member/service/domain/Account.java
@@ -1,0 +1,22 @@
+package com.hanghae.hanghaeplus3.member.service.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Account {
+    Long id;
+    Long memberId;
+    Long balance;
+
+    @Builder
+    public Account(Long id, Long memberId, Long balance) {
+        this.id = id;
+        this.memberId = memberId;
+        this.balance = balance;
+    }
+
+    public void chargeBalance(Long amount) {
+        balance += amount;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,6 +5,6 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DEV_DB_URL}
-    username: ${DEV_DB_USERNAME}
-    password: ${DEV_DB_PASSWORD}
+    url: jdbc:mysql://localhost:3306/hanghae
+    username: test
+    password: 1234

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ server:
 
 spring:
   profiles:
-    default: local
+    default: dev
 
 ---
 spring:

--- a/src/test/java/com/hanghae/hanghaeplus3/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/hanghae/hanghaeplus3/member/controller/MemberControllerTest.java
@@ -1,0 +1,72 @@
+package com.hanghae.hanghaeplus3.member.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanghae.hanghaeplus3.member.controller.request.ChargeBalanceRequest;
+import com.hanghae.hanghaeplus3.member.service.AccountService;
+import com.hanghae.hanghaeplus3.member.service.domain.Account;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+    @Autowired MockMvc mvc;
+    @MockBean
+    AccountService accountService;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("회원 계좌 잔고 조회")
+    public void findBalanceOf() throws Exception {
+        // given
+        given(accountService.findBalanceOf(any())).willReturn(any());
+        Long memberId = 1L;
+
+        // when
+        mvc.perform(get("/members/{id}/balance", memberId))
+                .andExpect(status().isOk());
+
+        // then
+    }
+
+    @Test
+    @DisplayName("회원 계좌 잔고 충전")
+    public void chargeBalance() throws Exception {
+        // given
+        given(accountService.chargeBalance(anyLong(), anyLong(), anyLong())).willReturn(getAccount());
+
+        Long memberId = 1L;
+        ChargeBalanceRequest request = ChargeBalanceRequest.builder().accountId(1L).chargeBalance(1000L).build();
+
+        // when
+        mvc.perform(put("/members/{id}/balance/charge", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andExpect(status().isOk());
+
+        // then
+    }
+
+    private <T> String toJson(T object) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(object);
+    }
+
+    private static Account getAccount() {
+        return Account.builder().id(1L).memberId(1L).balance(1000L).build();
+    }
+
+}


### PR DESCRIPTION
## e-커머스 서비스 > 잔액 조회, 잔액 충전

### 작업 내용 ✏️
- 엔티티가 도메인 역할을 할 수 있게 개발
  + 엔티티와 도메인을 분리하려고 하였지만 익숙치 않아 도메인을 어떻게 가져가야할지 잘 모르겠습니다. 😭
- Repository 클래스화 실패
  + 서비스와의 분리를 위해 repository 를 클래스로 분리하고 서비스 단에 있는 인터페이스된 레포지토리를 상속 받으려고 했지만...
  + JpaRepository와는 또 어떻게 연결을 시켜야할지 모르겠습니다...

### 주요 리뷰 사항 💡
- xxx

### 개선 사항 🔥
- 도메인과 엔티티를 분리할 생각입니다.